### PR TITLE
fix parallel compilation

### DIFF
--- a/src/rebar_compiler_dag.erl
+++ b/src/rebar_compiler_dag.erl
@@ -135,7 +135,7 @@ populate_deps(G, SourceExt, ArtifactExts) ->
     %% in depth already, and improvements should be driven at that level)
     IgnoredExts = [SourceExt | ArtifactExts],
     Vertices = digraph:vertices(G),
-    [refresh_dep(G, File)
+    [refresh_dep(G, digraph:vertex(G, File))
      || File <- Vertices,
         Ext <- [filename:extension(File)],
         not lists:member(Ext, IgnoredExts)],
@@ -211,7 +211,7 @@ restore_dag(G, File, CritMeta) ->
             %% the whole restore operation.
             #dag{vsn=?DAG_VSN, info={Vs, Es, CritMeta}} = binary_to_term(Data),
             [digraph:add_vertex(G, V, LastUpdated) || {V, LastUpdated} <- Vs],
-            [digraph:add_edge(G, V1, V2) || {_, V1, V2, _} <- Es],
+            [digraph:add_edge(G, V1, V2, Label) || {_, V1, V2, Label} <- Es],
             ok;
         {error, _Err} ->
             ok
@@ -234,8 +234,8 @@ maybe_rm_artifact_and_edge(G, OutDir, SrcExt, Ext, Source) ->
             false;
         false ->
             Edges = digraph:in_edges(G, Source),
-            Targets = [V2 || Edge <- Edges,
-                             {_E, _V1, V2, artifact} <- [digraph:edge(G, Edge)]],
+            Targets = [V1 || Edge <- Edges,
+                             {_E, V1, _V2, artifact} <- [digraph:edge(G, Edge)]],
             case Targets of
                 [] ->
                     Target = target(OutDir, Source, SrcExt, Ext),
@@ -243,8 +243,8 @@ maybe_rm_artifact_and_edge(G, OutDir, SrcExt, Ext, Source) ->
                     file:delete(Target);
                 [_|_] ->
                     lists:foreach(fun(Target) ->
-                        ?DEBUG("Source ~ts is gone, deleting artiface ~ts "
-                                "if it exists ~ts", [Source, Target]),
+                        ?DEBUG("Source ~ts is gone, deleting artifact ~ts "
+                                "if it exists", [Source, Target]),
                         file:delete(Target)
                     end, Targets)
             end,
@@ -288,8 +288,10 @@ prepopulate_deps(G, Compiler, InDirs, Source, DepOpts, Status) ->
     ok.
 
 %% check that a dep file is up to date
-refresh_dep(G, File) ->
-    {_, LastUpdated} = digraph:vertex(G, File),
+refresh_dep(_G, {artifact, _}) ->
+    %% ignore artifacts
+    ok;
+refresh_dep(G, {File, LastUpdated}) ->
     case filelib:last_modified(File) of
         0 ->
             %% Gone! Erase from the graph

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -73,7 +73,7 @@ needed_files(Graph, FoundFiles, _, AppInfo) ->
         fun(Erl) -> lists:any(
             fun(Edge) ->
                 {_E, _V1, _V2, Kind} = digraph:edge(Graph, Edge),
-                Kind =:= artifact
+                Kind =/= artifact
             end, digraph:in_edges(Graph, Erl)) end,
         lists:reverse([Dep || Dep <- DepErlsOrdered,
                               not lists:member(Dep, ErlFirstFiles)])

--- a/src/rebar_compiler_erl.erl
+++ b/src/rebar_compiler_erl.erl
@@ -70,7 +70,11 @@ needed_files(Graph, FoundFiles, _, AppInfo) ->
     %% that none other depend of; the former must be sequentially
     %% built, the rest is parallelizable.
     OtherErls = lists:partition(
-        fun(Erl) -> digraph:in_degree(Graph, Erl) > 0 end,
+        fun(Erl) -> lists:any(
+            fun(Edge) ->
+                {_E, _V1, _V2, Kind} = digraph:edge(Graph, Edge),
+                Kind =:= artifact
+            end, digraph:in_edges(Graph, Erl)) end,
         lists:reverse([Dep || Dep <- DepErlsOrdered,
                               not lists:member(Dep, ErlFirstFiles)])
     ),

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -206,7 +206,13 @@ compile_dirs(RebarOpts, BaseDir, SrcDirs, OutDir, CompileOpts) ->
 
     {ErlFirstFiles, ErlOptsFirst} = erl_first_files(RebarOpts, ErlOpts, BaseDir, NeededErlFiles),
     {DepErls, OtherErls} = lists:partition(
-                             fun(Source) -> digraph:in_degree(G, Source) > 0 end,
+                             fun(Source) -> lists:any(
+                                 fun(Edge) ->
+                                     {_E, _V1, _V2, Kind} = digraph:edge(G, Edge),
+                                     Kind =/= artifact
+                                 end,
+                                 digraph:in_edges(G, Source))
+                             end,
                              [File || File <- NeededErlFiles, not lists:member(File, ErlFirstFiles)]),
     SubGraph = digraph_utils:subgraph(G, DepErls),
     DepErlsOrdered = digraph_utils:topsort(SubGraph),


### PR DESCRIPTION
now all sources have at least one edge with 'artifact' label,
let's ignore it when choosing whether to compile in parallel
or sequentially